### PR TITLE
Add support for using secondary calendars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# 2020-05-08
+
+  * Added support for using a secondary calendar.  Use of this feature requires
+    invalidating all previous user sessions in deployed instances since the
+    required OAuth2 scope has changed.  This can be accomplished either by
+    removing the entries from the datastore or changing the session secret.
+
+# 2020-04-17
+
+  * Initial release.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ Console](https://console.cloud.google.com/apis/credentials/consent).
 To provide these settings, create a file called `settings.json` using the
 instructions in `settings.json-example`.
 
+## Choosing the calendar for events
+
+The example settings file creates calendar events on the primary calendar.
+Instead, a custom name can be specified and the named calendar will be created
+(if it doesn't exist) and events will be added there.
+
+*Note that if you choose to use this feature you must invalidate all previous
+user sessions since the required OAuth2 scopes are broader.*
+
 ## SMART on FHIR configuration
 
 The launch URL should be set to `/launch.html` on the appropriate server (e.g.

--- a/settings.json-example
+++ b/settings.json-example
@@ -1,4 +1,5 @@
 {
+  "calendar": "primary",
   "sessionCookieSecret": "secret key used to encrypt the session cookie",
   "oauth2": {
     "clientId": "an oauth2 client ID registered with Google Cloud",

--- a/user.js
+++ b/user.js
@@ -33,7 +33,10 @@ function getLoginUrl() {
   return newClient().generateAuthUrl({
     access_type: 'offline',
     prompt: 'select_account consent',
-    scope: ['https://www.googleapis.com/auth/calendar.events'],
+    scope: [
+      'https://www.googleapis.com/auth/calendar',
+      'https://www.googleapis.com/auth/calendar.events',
+    ]
   });
 }
 


### PR DESCRIPTION
This adds support for specifying a non-primary calendar in the settings file.
If specified, the named calendar will be created automatically and events will
be added there.

Closes issue #2.