### PR TITLE
Add cloud build script for the Angular app

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,16 @@
+steps:
+  # Install node packages
+  - name: "node"
+    entrypoint: "npm"
+    args: ["install"]
+
+  # Run Angular unit tests
+  - name: "trion/ng-cli-karma"
+    args: ["ng", "test", "--watch", "false"]
+    dir: "ui"
+
+  # Build Angualr production app
+  - name: "node"
+    entrypoint: "npm"
+    args: ["run", "build", "--prod"]
+    dir: "ui"


### PR DESCRIPTION
The script runs unit tests before build prod version Angular code. It can be used for CI in the future.