### PR TITLE
Smart on fhir v1

### DIFF
--- a/goserver/go.sum
+++ b/goserver/go.sum
@@ -271,6 +271,7 @@ golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=

--- a/goserver/smartonfhir/smartonfhirtest/smartonfhirtest.go
+++ b/goserver/smartonfhir/smartonfhirtest/smartonfhirtest.go
@@ -29,7 +29,7 @@ func StartFHIRServer(configPath, authBaseURL, tokenURL string) *httptest.Server 
 // StartFHIRTokenServer starts and returns a server that handles token exchange requests and
 // returns the given token as JSON in the response body. The handler will return status 400 if
 // the request contains form values that do not match the given ones.
-func StartFHIRTokenServer(code, redirectURI, clientID, token string) *httptest.Server {
+func StartFHIRTokenServer(code, redirectURI, clientID string, tokenJSON []byte) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.FormValue("grant_type") != "authorization_code" || r.FormValue("code") != code || r.FormValue("redirect_uri") != redirectURI || r.FormValue("client_id") != clientID {
 			w.WriteHeader(http.StatusBadRequest)
@@ -38,7 +38,7 @@ func StartFHIRTokenServer(code, redirectURI, clientID, token string) *httptest.S
 
 		w.Header()["Content-Type"] = []string{"application/json"}
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(fmt.Sprintf("{\"access_token\": \"%s\"}", token)))
+		w.Write(tokenJSON)
 	}))
 }
 


### PR DESCRIPTION
Added FHIR context parsing in smartonfhir package.
The token fetched/parsed by oauth2 library will put non-standard oauth2 fields in the token's "raw" fields. These fields contain important information such as encounter id and patient id. This PR will add logic to parse these fields and put them in a new struct called "FHIRContext".